### PR TITLE
Add support to build esp32 using Espressif SDK

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -6,12 +6,15 @@ RUN dpkg --add-architecture i386 && apt-get update \
     && apt-get install -y --no-install-recommends \
 		telnet \
 		libncurses5:i386 \
+		libusb-1.0-0 \
 		zip unzip \
 		sdcc libftdi-dev \
 		python3 python3-pip python3-wheel python3-dev python3-setuptools\
+		python-pip python-setuptools \
 		rake \
 		python3-numpy python3-scipy \
 		swig \
+		flex bison gperf \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSLO https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2 \
@@ -26,11 +29,32 @@ RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${
 RUN mkdir /new_home
 ENV HOME=/new_home
 
+# Upgrade pip to avoid need for wheel compiliation
+RUN pip3 install --upgrade pip
+
 RUN pip3 install flake8==3.8.4 pyusb==1.0.0b2 mock pyserial pre-commit tox opencv-python==4.5.1.48 pyelftools -vvv
 
 # Make pre-commit download and prepare all tools for python testing
 ADD .pre-commit-config.yaml /dummy/.pre-commit-config.yaml
 RUN cd /dummy && git init && pre-commit run && cd && rm -rf /dummy
+
+# In order to build ESP-32 based projects we need the Espressif SDK and
+# the build scripts need to know where to find it
+RUN mkdir -p /new_home/esp
+
+# First we setup the esp32 toolchain and add it to PATH
+RUN curl -fsSLO https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-97-gc752ad5-5.2.0.tar.gz \
+	&& tar -xzf xtensa-esp32-elf-linux64-1.22.0-97-gc752ad5-5.2.0.tar.gz -C /new_home/esp
+ENV PATH=$PATH:/new_home/esp/xtensa-esp32-elf/bin
+
+# ... as well as openocd for esp32
+RUN curl -fsSLO https://github.com/espressif/openocd-esp32/releases/download/v0.10.0-esp32-20210902/openocd-esp32-linux64-0.10.0-esp32-20210902.tar.gz \
+	&& tar -xzf openocd-esp32-linux64-0.10.0-esp32-20210902.tar.gz -C /new_home/esp
+
+RUN cd /new_home/esp && git clone -b release/v3.3 --recursive https://github.com/espressif/esp-idf.git
+RUN cd /new_home/esp/esp-idf && python2.7 -m pip install --user -r requirements.txt
+RUN cd /new_home/esp/esp-idf && ./install.sh esp32
+ENV IDF_PATH=/new_home/esp/esp-idf
 
 # Set the locale to make ruby open text files as UTF-8 default
 # (Encoding.default_external). Required to make html-proofer handle UTF-8.


### PR DESCRIPTION
New apt packages:
  - libusb-1.0-0 (for OpenOCD which SDK checks for)
  - python-pip python-setuptools (SDK 3.3 uses python2.7)
  - flex bison gperf (for the Kbuild config system)

  Other:
  - Uses curl to fetch the Espressif SDK and toolchain
  - Setup environment variable IDF_PATH, needed to build
