### PR TITLE
Add python3-opencv

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -15,6 +15,7 @@ RUN dpkg --add-architecture i386 && apt-get update \
 		python3-numpy python3-scipy \
 		swig \
 		flex bison gperf \
+		python3-opencv \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSLO https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2 \


### PR DESCRIPTION
There is an unsatisfied dependency to libGL.so.1 from open cv that makes
the unit tests in cf lib to fail. Introduced in
947bf596a5ce452b943187866a862218c23e41f9